### PR TITLE
Bump Gitlab Version to 8.16.6

### DIFF
--- a/list.json
+++ b/list.json
@@ -6,7 +6,7 @@
         "icon": "http://download.qnap.com/QPKG/images/QPKG/container/app_gitlab.png",
         "displayName": "GitLab",
         "name": "gitlab",
-        "version": "8.9.6",
+        "version": "8.16.6",
         "location": "https://hub.docker.com/r/sameersbn/gitlab/",
         "type": "app"
     }, 

--- a/template/gitlab/docker-compose.yml
+++ b/template/gitlab/docker-compose.yml
@@ -8,7 +8,7 @@ postgresql:
     - DB_EXTENSION=pg_trgm
 gitlab:
   restart: always
-  image: sameersbn/gitlab:8.9.6-1
+  image: sameersbn/gitlab:8.16.6
   links:
     - redis:redisio
     - postgresql:postgresql
@@ -19,9 +19,12 @@ gitlab:
     - DEBUG=false
     - GITLAB_PORT=10080
     - GITLAB_SSH_PORT=10022
+    - GITLAB_SECRETS_OTP_KEY_BASE=qcs-gitlab-app
     - GITLAB_SECRETS_DB_KEY_BASE=qcs-gitlab-app
+    - GITLAB_SECRETS_SECRET_KEY_BASE=qcs-gitlab-app
 redis:
   restart: always
   image: sameersbn/redis:latest
   command:
     - --loglevel warning
+


### PR DESCRIPTION
* [x] Configure `GITLAB_SECRETS_SECRET_KEY_BASE`
* [x] Configure `GITLAB_SECRETS_OTP_KEY_BASE`