### PR TITLE
Fix error and invalid URL.

### DIFF
--- a/list.json
+++ b/list.json
@@ -147,7 +147,7 @@
         "displayName": "Ubuntu",
         "name": "ubuntu-xenial-armhf",
         "version": "16.04",
-        "location": "http://172.17.28.162/~terrychu/ubuntu-xenial_16.04_20180212_armhf.tar.gz",
+        "location": "http://download.qnap.com/QPKG/container/ubuntu-xenial_16.04_20180212_armhf.tar.gz",
         "type": "lxc",
         "kernelVersion": "4.2.8"
     },
@@ -435,7 +435,7 @@
         "displayName": "Ubuntu",
         "name": "arm64v8/ubuntu",
         "version": "xenial",
-        "location": "https://hub.docker.com/r/arm32v7/ubuntu://hub.docker.com/r/arm64v8/ubuntu/",
+        "location": "https://hub.docker.com/r/arm64v8/ubuntu/",
         "type": "docker"
     },
     {


### PR DESCRIPTION
Fix Ubuntu armhf lxc image URL and Ubuntu arm64 dockerhub link.